### PR TITLE
Remove wulkanowy/bridge and wulkanowy/sdk-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@
 - [wulkanowy/qr](https://github.com/wulkanowy/qr) - [![kotlin](images/kotlin.svg)](https://kotlinlang.org/)
  [![js](images/js.svg)](https://developer.mozilla.org/docs/Web/JavaScript) [![dart](images/dart.svg)](https://dart.dev/) [![c#](images/csharp.svg)](https://docs.microsoft.com/dotnet/csharp/) [![php](images/php.svg)](https://www.php.net/) konwerter kodów QR
 - [wulkanowy/uonet-request-signer](https://github.com/wulkanowy/uonet-request-signer) - [![kotlin](images/kotlin.svg)](https://kotlinlang.org/)
-- [wulkanowy/bridge](https://github.com/wulkanowy/bridge) - [![js](images/js.svg)](https://developer.mozilla.org/docs/Web/JavaScript) serwis umożliwiający dostęp do danych z dziennika  poprzez udokumentowane API
 - [szkolny-eu/FSLogin](https://github.com/szkolny-eu/FSLogin) - [![kotlin](images/kotlin.svg)](https://kotlinlang.org/)
  ADFS & Vulcan CUFS Login module 
  - [marioneq4958/FSLogin](https://github.com/marioneq4958/FSLogin) - [![python](images/python.svg)](https://python.org/) CUFS & ADFS UONET+ login module
@@ -76,7 +75,6 @@
 #### 🤖 API
 - [wulkanowy/sdk](https://github.com/wulkanowy/sdk) - [![kotlin](images/kotlin.svg)](https://kotlinlang.org/)
  ujednolicony sposób pobierania danych poprzez mobilne API oraz scraping
-- [wulkanowy/sdk-node](https://github.com/wulkanowy/sdk-node) - [![js](images/js.svg)](https://developer.mozilla.org/docs/Web/JavaScript) (WIP)
 - [Capure/vulcan-api-js](https://github.com/Capure/vulcan-api-js) - [![js](images/js.svg)](https://developer.mozilla.org/docs/Web/JavaScript)
 - [kapi2289/vulcan-api](https://github.com/kapi2289/vulcan-api) - [![python](images/python.svg)](https://python.org/)
 - [drobotk/vulcan-sdk-py](https://github.com/drobotk/vulcan-sdk-py) - [![python](images/python.svg)](https://python.org/) (WIP)


### PR DESCRIPTION
Projekty już od jakiegoś czasu są zarchiwizowane. sdk-node, którego używa bridge od dawna nie działa i używa scrappera, metoda ta jest bardzo utrudniana przez VULCANa.